### PR TITLE
Update heap_used variable to be defined and to pull from ES JVM stats.

### DIFF
--- a/check_elasticsearch_jvm
+++ b/check_elasticsearch_jvm
@@ -124,6 +124,7 @@ class ElasticSearchJvmCheck(NagiosCheck):
         dict2perfdata(es_node_jvm["nodes"][myid]["jvm"]["gc"], metrics)
 
         heap_used_b = int(es_stats['nodes'][myid]['jvm']['mem']['heap_used_in_bytes'])
+        heap_used   = es_stats['nodes'][myid]['jvm']['mem']['heap_used']
         heap_max_b  = int(es_node ['nodes'][myid]['jvm']['mem']['heap_max_in_bytes'])
         heap_max    = es_node ['nodes'][myid]['jvm']['mem']['heap_max']
         heap_usage_percent = (float(heap_used_b)/float(heap_max_b))*100


### PR DESCRIPTION
Prior to this change, I got 'Unhandled Python exception:
NameError("global name 'heap_used' is not defined",)'
